### PR TITLE
Add system get_status and get_load queries

### DIFF
--- a/gli4py/glinet.py
+++ b/gli4py/glinet.py
@@ -135,6 +135,12 @@ class GLinet(Consumer):
     async def router_info(self) -> dict:
         return await self._request(self.gen_sid_payload('call', ['system', 'get_info'], self.sid))
 
+    async def router_get_status(self) -> dict:
+        return await self._request(self.gen_sid_payload('call', ['system', 'get_status'], self.sid))
+
+    async def router_get_load(self) -> dict:
+        return await self._request(self.gen_sid_payload('call', ['system', 'get_load'], self.sid))
+
     async def router_mac(self) -> dict:
         return await self._request(self.gen_sid_payload('call', ['macclone', 'get_mac'], self.sid))
 


### PR DESCRIPTION
Note that `get_status` contains quite a lot of data. This is still kept as just one function as in the HA component having to only call the API once for all this data reduces overhead compared to having to call it every time a subset of this data is requested.