### PR TITLE
Run the live test suite on one event loop

### DIFF
--- a/tests/test_glinet.py
+++ b/tests/test_glinet.py
@@ -7,6 +7,10 @@ from gli4py.enums import TailscaleConnection
 from gli4py.error_handling import NonZeroResponse
 from gli4py.glinet import GLinet, NEW_VPN_CLIENT_VERSION
 
+# All tests share one GLinet client (and one aiohttp session), so they must
+# run on a single event loop.
+pytestmark = pytest.mark.asyncio(loop_scope="module")
+
 router = GLinet(base_url="http://192.168.0.1/rpc")
 PERFORM_DISTRUPTIVE_TESTS = False
 
@@ -41,16 +45,6 @@ models = [
 ]
 
 
-@pytest.fixture(scope="session")
-def event_loop():
-    """Create a new event loop for each test session."""
-    policy = asyncio.get_event_loop_policy()
-    loop = policy.new_event_loop()
-    yield loop
-    loop.close()
-
-
-@pytest.mark.asyncio
 async def test_router_reachable() -> None:
     """Test if the router is reachable."""
     response = await router.router_reachable()
@@ -58,7 +52,6 @@ async def test_router_reachable() -> None:
     print(response)
 
 
-@pytest.mark.asyncio
 async def test_login() -> None:
     """Test logging into the router."""
     with open("router_pwd", "r", encoding="utf-8") as file:
@@ -69,7 +62,6 @@ async def test_login() -> None:
     print(router.sid)
 
 
-@pytest.mark.asyncio
 async def test_router_info() -> None:
     """Test retrieving router information."""
     response = await router.router_info()
@@ -79,7 +71,6 @@ async def test_router_info() -> None:
     print(response)
 
 
-@pytest.mark.asyncio
 async def test_router_get_status() -> None:
     """Test retrieving router status."""
     response = await router.router_get_status()
@@ -93,7 +84,6 @@ async def test_router_get_status() -> None:
     print(response)
 
 
-@pytest.mark.asyncio
 async def test_router_get_load() -> None:
     """Test retrieving router load information."""
     response = await router.router_get_load()
@@ -103,7 +93,6 @@ async def test_router_get_load() -> None:
     print(response)
 
 
-@pytest.mark.asyncio
 async def test_router_mac() -> None:
     """Test retrieving the router's MAC address."""
     response = await router.router_mac()
@@ -111,7 +100,6 @@ async def test_router_mac() -> None:
     print(response)
 
 
-@pytest.mark.asyncio
 async def test_connected_clients() -> None:
     """Test retrieving connected clients."""
     clients = await router.connected_clients()
@@ -119,7 +107,6 @@ async def test_connected_clients() -> None:
     assert len(clients) > 0
 
 
-@pytest.mark.asyncio
 async def test_wifi_ifaces_get() -> None:
     """Test retrieving WiFi interfaces."""
     wifi_ifaces = await router.wifi_ifaces_get()
@@ -131,7 +118,6 @@ async def test_wifi_ifaces_get() -> None:
         assert "key" in iface
 
 
-@pytest.mark.asyncio
 async def test_wifi_ifaces_set_enabled() -> None:
     """Test enabling/disabling a WiFi interface."""
 
@@ -151,7 +137,6 @@ async def test_wifi_ifaces_set_enabled() -> None:
     assert iface_enabled_after != iface_enabled
 
 
-@pytest.mark.asyncio
 async def test_connected_to_internet() -> None:
     """Test checking if the router is connected to the internet."""
     response = await router.connected_to_internet()
@@ -160,7 +145,6 @@ async def test_connected_to_internet() -> None:
     assert "ip" in response
 
 
-@pytest.mark.asyncio
 async def test_ping() -> None:
     """Test pinging a host."""
     response = await router.ping("google.com")
@@ -172,7 +156,6 @@ async def test_ping() -> None:
     assert not response
 
 
-@pytest.mark.asyncio
 async def test_wireguard_client_list() -> None:
     """Test retrieving the list of WireGuard clients."""
     response = await router.wireguard_client_list()
@@ -180,7 +163,6 @@ async def test_wireguard_client_list() -> None:
     # assert(response['enable'] in [True,False])
 
 
-@pytest.mark.asyncio
 async def test_wireguard_client_state() -> None:
     """Test retrieving the state of the WireGuard client."""
     # We need to get the proper firmware version for this
@@ -198,7 +180,6 @@ async def test_wireguard_client_state() -> None:
         assert first_status["status"] in [0, 1, 2]
 
 
-@pytest.mark.asyncio
 async def test_wireguard_start() -> None:
     """Test starting the WireGuard client."""
     assert PERFORM_DISTRUPTIVE_TESTS, (
@@ -236,7 +217,6 @@ async def test_wireguard_start() -> None:
             pytest.fail("WireGuard client took too long to connect.")
 
 
-@pytest.mark.asyncio
 async def test_wireguard_stop() -> None:
     """Test stopping the WireGuard client."""
     assert PERFORM_DISTRUPTIVE_TESTS, (
@@ -278,7 +258,6 @@ async def test_wireguard_stop() -> None:
             pytest.fail("WireGuard client took too long to disconnect.")
 
 
-@pytest.mark.asyncio
 async def test_tailscale_status() -> None:
     """Test retrieving the Tailscale status."""
     response = await router._tailscale_status()  # pylint: disable=protected-access
@@ -286,7 +265,6 @@ async def test_tailscale_status() -> None:
     assert dict(response).get("status", 0) in [1, 2, 3, 4] or response == []
 
 
-@pytest.mark.asyncio
 async def test_tailscale_connection() -> None:
     """Test retrieving the Tailscale connection state."""
     response = await router.tailscale_connection_state()
@@ -294,7 +272,6 @@ async def test_tailscale_connection() -> None:
     assert response in [TailscaleConnection.DISCONNECTED, TailscaleConnection.CONNECTED]
 
 
-@pytest.mark.asyncio
 async def test_tailscale_configured() -> None:
     """Test checking if Tailscale is configured."""
     response = await router.tailscale_configured()
@@ -302,7 +279,6 @@ async def test_tailscale_configured() -> None:
     assert response in [True, False]
 
 
-@pytest.mark.asyncio
 async def test_tailscale_get_config() -> None:
     """Test retrieving the Tailscale configuration."""
     response = await router._tailscale_get_config()  # pylint: disable=protected-access
@@ -310,7 +286,6 @@ async def test_tailscale_get_config() -> None:
     assert response["enabled"] in [True, False]
 
 
-@pytest.mark.asyncio
 async def test_tailscale_start() -> None:
     """Test starting Tailscale."""
     assert PERFORM_DISTRUPTIVE_TESTS, (
@@ -321,7 +296,6 @@ async def test_tailscale_start() -> None:
     assert result in [True, False]
 
 
-@pytest.mark.asyncio
 async def test_tailscale_stop() -> None:
     """Test stopping Tailscale."""
     assert PERFORM_DISTRUPTIVE_TESTS, (
@@ -332,7 +306,6 @@ async def test_tailscale_stop() -> None:
     assert result in [True, False]
 
 
-@pytest.mark.asyncio
 async def test_router_reboot() -> None:
     """Test rebooting the router."""
     assert PERFORM_DISTRUPTIVE_TESTS, (


### PR DESCRIPTION
## Problem

The live suite shares one module-level `GLinet` client (and therefore one aiohttp session), but with current pytest-asyncio (>= 0.26, tested on 1.4.0) the custom session-scoped `event_loop` fixture is silently ignored and every test gets its own function-scoped loop. The session binds to the first test's loop, so every subsequent test fails with `RuntimeError: Event loop is closed` — the live suite is unusable beyond `test_router_reachable`.

## Fix

- Mark the module with `pytest.mark.asyncio(loop_scope="module")` so all tests share one loop.
- Remove the obsolete `event_loop` fixture and the per-test `@pytest.mark.asyncio` markers (they would override the module loop scope back to function scope).

Test-only change; no library code touched.

## Tested on real hardware

GL-MT6000 (Flint 2), firmware 4.9.0, pytest 9.1.1 / pytest-asyncio 1.4.0, non-disruptive tests only (`-k "not set_enabled and not wireguard_start and not wireguard_stop and not tailscale_start and not tailscale_stop and not reboot"`).

**Before (master):**
```
test_router_reachable PASSED
test_login FAILED                 RuntimeError: Event loop is closed
test_router_info FAILED           RuntimeError: Event loop is closed
... (all 14 remaining tests fail the same way)
================== 15 failed, 1 passed, 6 deselected in 1.06s ==================
```

**After (this branch):**
```
test_router_reachable PASSED
test_login PASSED
test_router_info PASSED
test_router_get_status PASSED
test_router_get_load PASSED
test_router_mac FAILED            (macclone disabled on this unit)
test_connected_clients PASSED
test_wifi_ifaces_get PASSED
test_connected_to_internet FAILED (fw 4.9 returns {'detected': 0} without 'ip')
test_ping FAILED                  (fw 4.9 ping of 0.0.0.1 returns truthy)
test_wireguard_client_list PASSED
test_wireguard_client_state FAILED (no WireGuard client configured on this unit)
test_tailscale_status FAILED      (tailscale configured but disconnected: status 0)
test_tailscale_connection PASSED
test_tailscale_configured PASSED
test_tailscale_get_config PASSED
================= 5 failed, 11 passed, 6 deselected in 26.41s ==================
```

The 5 remaining failures are pre-existing assertion mismatches that depend on device configuration/firmware (they fail identically on master once the loop issue is fixed) — happy to follow up on those separately if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)