### PR TITLE
Add WAN and network status routes

### DIFF
--- a/gli4py/glinet.py
+++ b/gli4py/glinet.py
@@ -229,6 +229,59 @@ class GLinet(Consumer):
             self.gen_sid_payload("call", ["edgerouter", "get_status"], self.sid)
         )
 
+    async def wan_cable_state(self) -> dict:
+        """WAN cable presence and macclone state, requires authentication
+        {"cable_enabled":True,"cable_inserted":True,"macclone_enabled":False}
+        The explicit empty params object is required; without it the router
+        answers HTTP 500.
+        """
+        return await self._request(
+            self.gen_sid_payload("call", ["network", "check_wan_cable", {}], self.sid)
+        )
+
+    async def wan_status(self) -> dict:
+        """WAN connection status, requires authentication
+        {"ipv4":{"dns":["192.0.2.53"],"gateway":"192.0.2.1","ip":"192.0.2.10/21"},
+        "mode":0,"protocol":"dhcp","status":1}
+        """
+        return await self._request(
+            self.gen_sid_payload("call", ["cable", "get_status", {}], self.sid)
+        )
+
+    async def wan_info(self) -> list:
+        """Address details for each WAN interface, requires authentication
+        [{"info":{"ipaddr":"192.0.2.10","netmask":"255.255.248.0","prefix":21},"interface":"wan"}]
+        """
+        response = await self._request(
+            self.gen_sid_payload("call", ["lan", "get_wan_info", {}], self.sid)
+        )
+        return response.get("wan_info", [])
+
+    async def ethernet_ports_status(self) -> list:
+        """Link status of each ethernet port, requires authentication
+        [{"duplex":"full","name":"WAN","speed":1000}]
+        """
+        response = await self._request(
+            self.gen_sid_payload("call", ["cable", "get_ports_status", {}], self.sid)
+        )
+        return response.get("ports", [])
+
+    async def network_mode(self) -> str:
+        """The operating mode, e.g. router/ap/repeater, requires authentication."""
+        response = await self._request(
+            self.gen_sid_payload("call", ["netmode", "get_mode", {}], self.sid)
+        )
+        return response.get("mode", "")
+
+    async def network_interfaces_status(self) -> list:
+        """Online/up state of each network interface, requires authentication
+        [{"interface":"wan","online":True,"up":True}]
+        """
+        response = await self._request(
+            self.gen_sid_payload("call", ["system", "get_network_status", {}], self.sid)
+        )
+        return response.get("network", [])
+
     async def list_all_clients(self) -> dict:
         """Gets all clients connected to the router."""
         return await self._request(

--- a/tests/test_glinet.py
+++ b/tests/test_glinet.py
@@ -156,6 +156,59 @@ async def test_ping() -> None:
     assert not response
 
 
+async def test_wan_cable_state() -> None:
+    """Test retrieving WAN cable state."""
+    response = await router.wan_cable_state()
+    print(response)
+    assert response["cable_enabled"] in [True, False]
+    assert response["cable_inserted"] in [True, False]
+
+
+async def test_wan_status() -> None:
+    """Test retrieving WAN connection status."""
+    response = await router.wan_status()
+    print(response)
+    assert "status" in response
+    assert "protocol" in response
+
+
+async def test_wan_info() -> None:
+    """Test retrieving WAN interface address details."""
+    response = await router.wan_info()
+    print(response)
+    assert isinstance(response, list)
+    for entry in response:
+        assert "interface" in entry
+        assert "info" in entry
+
+
+async def test_ethernet_ports_status() -> None:
+    """Test retrieving ethernet port link status."""
+    ports = await router.ethernet_ports_status()
+    print(ports)
+    assert isinstance(ports, list)
+    for port in ports:
+        assert "name" in port
+
+
+async def test_network_mode() -> None:
+    """Test retrieving the operating mode."""
+    mode = await router.network_mode()
+    print(mode)
+    assert isinstance(mode, str)
+    assert mode != ""
+
+
+async def test_network_interfaces_status() -> None:
+    """Test retrieving per-interface online/up state."""
+    interfaces = await router.network_interfaces_status()
+    print(interfaces)
+    assert isinstance(interfaces, list)
+    for entry in interfaces:
+        assert "interface" in entry
+        assert entry["online"] in [True, False]
+
+
 async def test_wireguard_client_list() -> None:
     """Test retrieving the list of WireGuard clients."""
     response = await router.wireguard_client_list()

--- a/tests/test_glinet.py
+++ b/tests/test_glinet.py
@@ -7,6 +7,10 @@ from gli4py.enums import TailscaleConnection
 from gli4py.error_handling import NonZeroResponse
 from gli4py.glinet import GLinet, NEW_VPN_CLIENT_VERSION
 
+# All tests share one GLinet client (and one aiohttp session), so they must
+# run on a single event loop.
+pytestmark = pytest.mark.asyncio(loop_scope="module")
+
 router = GLinet(base_url="http://192.168.0.1/rpc")
 PERFORM_DISTRUPTIVE_TESTS = False
 
@@ -41,16 +45,6 @@ models = [
 ]
 
 
-@pytest.fixture(scope="session")
-def event_loop():
-    """Create a new event loop for each test session."""
-    policy = asyncio.get_event_loop_policy()
-    loop = policy.new_event_loop()
-    yield loop
-    loop.close()
-
-
-@pytest.mark.asyncio
 async def test_router_reachable() -> None:
     """Test if the router is reachable."""
     response = await router.router_reachable()
@@ -58,7 +52,6 @@ async def test_router_reachable() -> None:
     print(response)
 
 
-@pytest.mark.asyncio
 async def test_login() -> None:
     """Test logging into the router."""
     with open("router_pwd", "r", encoding="utf-8") as file:
@@ -69,7 +62,6 @@ async def test_login() -> None:
     print(router.sid)
 
 
-@pytest.mark.asyncio
 async def test_router_info() -> None:
     """Test retrieving router information."""
     response = await router.router_info()
@@ -79,7 +71,6 @@ async def test_router_info() -> None:
     print(response)
 
 
-@pytest.mark.asyncio
 async def test_router_get_status() -> None:
     """Test retrieving router status."""
     response = await router.router_get_status()
@@ -93,7 +84,6 @@ async def test_router_get_status() -> None:
     print(response)
 
 
-@pytest.mark.asyncio
 async def test_router_get_load() -> None:
     """Test retrieving router load information."""
     response = await router.router_get_load()
@@ -103,7 +93,6 @@ async def test_router_get_load() -> None:
     print(response)
 
 
-@pytest.mark.asyncio
 async def test_router_mac() -> None:
     """Test retrieving the router's MAC address."""
     response = await router.router_mac()
@@ -111,7 +100,6 @@ async def test_router_mac() -> None:
     print(response)
 
 
-@pytest.mark.asyncio
 async def test_connected_clients() -> None:
     """Test retrieving connected clients."""
     clients = await router.connected_clients()
@@ -119,7 +107,6 @@ async def test_connected_clients() -> None:
     assert len(clients) > 0
 
 
-@pytest.mark.asyncio
 async def test_wifi_ifaces_get() -> None:
     """Test retrieving WiFi interfaces."""
     wifi_ifaces = await router.wifi_ifaces_get()
@@ -131,7 +118,6 @@ async def test_wifi_ifaces_get() -> None:
         assert "key" in iface
 
 
-@pytest.mark.asyncio
 async def test_wifi_ifaces_set_enabled() -> None:
     """Test enabling/disabling a WiFi interface."""
 
@@ -151,7 +137,6 @@ async def test_wifi_ifaces_set_enabled() -> None:
     assert iface_enabled_after != iface_enabled
 
 
-@pytest.mark.asyncio
 async def test_connected_to_internet() -> None:
     """Test checking if the router is connected to the internet."""
     response = await router.connected_to_internet()
@@ -160,7 +145,6 @@ async def test_connected_to_internet() -> None:
     assert "ip" in response
 
 
-@pytest.mark.asyncio
 async def test_ping() -> None:
     """Test pinging a host."""
     response = await router.ping("google.com")
@@ -172,7 +156,6 @@ async def test_ping() -> None:
     assert not response
 
 
-@pytest.mark.asyncio
 async def test_wireguard_client_list() -> None:
     """Test retrieving the list of WireGuard clients."""
     response = await router.wireguard_client_list()
@@ -180,7 +163,6 @@ async def test_wireguard_client_list() -> None:
     # assert(response['enable'] in [True,False])
 
 
-@pytest.mark.asyncio
 async def test_wireguard_client_state() -> None:
     """Test retrieving the state of the WireGuard client."""
     # We need to get the proper firmware version for this
@@ -198,7 +180,6 @@ async def test_wireguard_client_state() -> None:
         assert first_status["status"] in [0, 1, 2]
 
 
-@pytest.mark.asyncio
 async def test_wireguard_start() -> None:
     """Test starting the WireGuard client."""
     assert PERFORM_DISTRUPTIVE_TESTS, (
@@ -236,7 +217,6 @@ async def test_wireguard_start() -> None:
             pytest.fail("WireGuard client took too long to connect.")
 
 
-@pytest.mark.asyncio
 async def test_wireguard_stop() -> None:
     """Test stopping the WireGuard client."""
     assert PERFORM_DISTRUPTIVE_TESTS, (
@@ -278,7 +258,6 @@ async def test_wireguard_stop() -> None:
             pytest.fail("WireGuard client took too long to disconnect.")
 
 
-@pytest.mark.asyncio
 async def test_tailscale_status() -> None:
     """Test retrieving the Tailscale status."""
     response = await router._tailscale_status()  # pylint: disable=protected-access
@@ -286,7 +265,6 @@ async def test_tailscale_status() -> None:
     assert dict(response).get("status", 0) in [1, 2, 3, 4] or response == []
 
 
-@pytest.mark.asyncio
 async def test_tailscale_connection() -> None:
     """Test retrieving the Tailscale connection state."""
     response = await router.tailscale_connection_state()
@@ -294,7 +272,6 @@ async def test_tailscale_connection() -> None:
     assert response in [TailscaleConnection.DISCONNECTED, TailscaleConnection.CONNECTED]
 
 
-@pytest.mark.asyncio
 async def test_tailscale_configured() -> None:
     """Test checking if Tailscale is configured."""
     response = await router.tailscale_configured()
@@ -302,7 +279,6 @@ async def test_tailscale_configured() -> None:
     assert response in [True, False]
 
 
-@pytest.mark.asyncio
 async def test_tailscale_get_config() -> None:
     """Test retrieving the Tailscale configuration."""
     response = await router._tailscale_get_config()  # pylint: disable=protected-access
@@ -310,7 +286,6 @@ async def test_tailscale_get_config() -> None:
     assert response["enabled"] in [True, False]
 
 
-@pytest.mark.asyncio
 async def test_tailscale_start() -> None:
     """Test starting Tailscale."""
     assert PERFORM_DISTRUPTIVE_TESTS, (
@@ -321,7 +296,6 @@ async def test_tailscale_start() -> None:
     assert result in [True, False]
 
 
-@pytest.mark.asyncio
 async def test_tailscale_stop() -> None:
     """Test stopping Tailscale."""
     assert PERFORM_DISTRUPTIVE_TESTS, (
@@ -332,7 +306,6 @@ async def test_tailscale_stop() -> None:
     assert result in [True, False]
 
 
-@pytest.mark.asyncio
 async def test_router_reboot() -> None:
     """Test rebooting the router."""
     assert PERFORM_DISTRUPTIVE_TESTS, (


### PR DESCRIPTION
Adds six read-only methods surfacing WAN/network state, the API groundwork for WAN status sensors in the Home Assistant integration (HarvsG/ha-glinet4-integration#7 — internet connectivity, WAN IP, port link state, operating mode):

| Method | RPC | Returns |
|---|---|---|
| `wan_cable_state()` | `network check_wan_cable` | cable enabled/inserted, macclone flag |
| `wan_status()` | `cable get_status` | protocol, IPv4 address/gateway/DNS, status |
| `wan_info()` | `lan get_wan_info` | per-WAN-interface address details |
| `ethernet_ports_status()` | `cable get_ports_status` | per-port duplex/speed |
| `network_mode()` | `netmode get_mode` | `router` / `ap` / `repeater` / … |
| `network_interfaces_status()` | `system get_network_status` | per-interface online/up |

Notes:
- Every call passes an explicit empty params object — a bare `network.check_wan_cable` call gets HTTP 500 from nginx (reproduced on GL-MT6000 fw 4.9.0).
- Response shapes documented in the docstrings are from the sanitized GL-MT6000 capture in the [glinet-registry](https://github.com/shauneccles/glinet-registry) device profile.

**Stacked on #31** (first commit is #31's fix — without it the live suite can't run past its first test). Review the last commit only; I'll rebase once #31 lands.

## Tested on real hardware

GL-MT6000 (Flint 2), firmware 4.9.0, router mode, live run of the six new tests plus reachability/login:

```
tests/test_glinet.py::test_router_reachable PASSED                       [ 12%]
tests/test_glinet.py::test_login PASSED                                  [ 25%]
tests/test_glinet.py::test_wan_cable_state PASSED                        [ 37%]
tests/test_glinet.py::test_wan_status PASSED                             [ 50%]
tests/test_glinet.py::test_wan_info PASSED                               [ 62%]
tests/test_glinet.py::test_ethernet_ports_status PASSED                  [ 75%]
tests/test_glinet.py::test_network_mode PASSED                           [ 87%]
tests/test_glinet.py::test_network_interfaces_status PASSED              [100%]
======================= 8 passed, 20 deselected in 0.20s =======================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)